### PR TITLE
Add smashing magazine article as an external link to list of posts

### DIFF
--- a/_includes/layouts/post/post.njk
+++ b/_includes/layouts/post/post.njk
@@ -21,9 +21,9 @@ templateClass: tmpl-post
             Caption: {{coverImageCaption or coverImageAlt}}
           </p>
         </caption>
-      {% endif %}
 
-      <hr style="color: var(--color-gray-80);">
+        <hr style="color: var(--color-gray-80);">
+      {% endif %}
 
 
       {{ content | safe }}

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -4,6 +4,17 @@
   style="counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }}"
 >
   {% for post in postslist | reverse %}
+    {% if post.data.externalUrl %}
+      {% set postUrl = post.data.externalUrl %}
+    {% else %}
+      {% set postUrl = post.url | url %}
+    {% endif %}
+
+    {% macro decideTargetBlank(hasExternalUrl) %}
+      {% if hasExternalUrl %}target="_blank"{% endif %}
+      {% if hasExternalUrl %}rel="noopener"{% endif %}
+    {% endmacro %}
+
     <li class="post-list__item{% if post.url == url %} postlist-item-active{% endif %}">
 
       <span class="post-list__item--date">
@@ -11,8 +22,12 @@
       </span>
 
       <h3 class="post-list__item-title-url font-size-xlarge d-font-size-xxlarge">
-        <a href="{{ post.url | url }}" class="post-list__item-link no-text-decoration color-navy">
-          {% if post.data.title %}{{ post.data.title }}
+        <a href="{{ postUrl }}" class="post-list__item-link no-text-decoration color-navy" {{decideTargetBlank(post.data.externalUrl)}}>
+          {% if post.data.title %}
+            {{ post.data.title }}
+            {% if post.data.externalUrl %}
+              <span>↗️</span>
+            {% endif %}
           {% else %}
             <span>{{ post.url }}</span>
           {% endif %}

--- a/posts/tech/feb-2021/smashing-magazine-article.md
+++ b/posts/tech/feb-2021/smashing-magazine-article.md
@@ -1,0 +1,6 @@
+---
+title: "Creating An Outside Focus And Click Handler React Component"
+externalUrl: https://www.smashingmagazine.com/2021/03/outside-focus-click-handler-react-component/
+tags: ["react", "opensource", "writing", "tech", "smashingmagazine"]
+date: 2021-03-03
+--- 


### PR DESCRIPTION
1. add smashing magazine article as an external link to the list of posts
2. fix <hr > logic for styling with cover image